### PR TITLE
Fix Threads not being set to daemon

### DIFF
--- a/src/main/java/org/fit/cssbox/swingbox/BrowserPane.java
+++ b/src/main/java/org/fit/cssbox/swingbox/BrowserPane.java
@@ -515,7 +515,7 @@ public class BrowserPane extends JEditorPane
                             loadPage(newPage, oldPage, in, document);
                         }
                     });
-
+                    t.setDaemon(true);
                     t.start();
                 }
             }

--- a/src/main/java/org/fit/cssbox/swingbox/demo/BrowserComparison.java
+++ b/src/main/java/org/fit/cssbox/swingbox/demo/BrowserComparison.java
@@ -107,6 +107,7 @@ public class BrowserComparison extends JFrame
                         loadPage(txt.getText());
                     }
                 });
+                t.setDaemon(true);
                 t.start();
             }
         });
@@ -123,6 +124,7 @@ public class BrowserComparison extends JFrame
                         loadPage(txt.getText());
                     }
                 });
+                t.setDaemon(true);
                 t.start();
             }
         });


### PR DESCRIPTION
The Threads for loading pages asynchronously were not set for daemon.
This may have prevented application exit with no other Threads active.
The Threads used in comparison example were also fixed for consistency.
