### PR TITLE
Remove harmful dependencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Version 1.1.2 - Feb 20, 2015
+- upgrade to cssbox-4.8.1 (same dependency changes as below - https://github.com/KajKandler/CSSBox)
+- declare dependencies on xerces and xml-api's as provided, making the component friendlier to cooperate with other components in environments where isolated class loaders are used, i.e. IDE plugin development - implementations for these are shipped with JRE 6 or younger
 Version 1.1 - Sep 1, 2014
 - Improved scrollToReference API
 - Content clipping fixes according to the current CSSBox API

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>net.sf.cssbox</groupId>
 	<artifactId>swingbox</artifactId>
-	<version>1.2-SNAPSHOT</version>
+	<version>1.1.1</version>
 	<name>SwingBox</name>
 	<description>SwingBox is a Java Swing component that allows displaying the (X)HTML documents including the CSS support. It is designed as a JEditorPane replacement with considerably better rendering results. SwingBox is pure Java and it is using the CSSBox rendering engine for rendering the documents.</description>
 	<url>http://cssbox.sourceforge.net/swingbox</url>
@@ -39,6 +39,14 @@
 			</roles>
 		</developer>
 	</developers>
+	<contributors>
+    		<contributor>
+      			<name>Kaj Kandler</name>
+      			<email>kajkandler@conficio.com</email>
+      			<organization>Conficio</organization>
+      			<organizationUrl>http://conficio.com</organizationUrl>
+    		</contributor>
+  	</contributors>
 
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
@@ -52,6 +60,18 @@
 		<developerConnection>scm:git:git@github.com:radkovo/SwingBox.git</developerConnection>
 	  <tag>HEAD</tag>
   </scm>
+	<distributionManagement>
+        <repository>
+                <id>bds-artifactory</id>
+                <name>integration-releases</name>
+                <url>http://artifactory.blackducksoftware.com:8081/artifactory/integration</url>
+        </repository>
+        <snapshotRepository>
+                <id>artifactory.blackducksoftware.com</id>
+                <name>integration-snapshots</name>
+                <url>http://artifactory.blackducksoftware.com:8081/artifactory/integration-snapshot</url>
+        </snapshotRepository>
+	</distributionManagement>
 	
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -154,12 +174,24 @@
 		<dependency>
 			<groupId>net.sf.cssbox</groupId>
 			<artifactId>cssbox</artifactId>
-			<version>4.7</version>
+			<version>4.8.1</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>
+		</dependency>
+		<dependency>
+			<groupId>xml-apis</groupId>
+			<artifactId>xml-apis</artifactId>
+			<version>1.4.01</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.sf.cssbox</groupId>
+			<artifactId>jstyleparser</artifactId>
+			<version>1.20</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>net.sf.cssbox</groupId>
 	<artifactId>swingbox</artifactId>
-	<version>1.1.2</version>
+	<version>1.2-SNAPSHOT</version>
 	<name>SwingBox</name>
 	<description>SwingBox is a Java Swing component that allows displaying the (X)HTML documents including the CSS support. It is designed as a JEditorPane replacement with considerably better rendering results. SwingBox is pure Java and it is using the CSSBox rendering engine for rendering the documents.</description>
 	<url>http://cssbox.sourceforge.net/swingbox</url>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>net.sf.cssbox</groupId>
 	<artifactId>swingbox</artifactId>
-	<version>1.2-SNAPSHOT</version>
+	<version>1.1.2</version>
 	<name>SwingBox</name>
 	<description>SwingBox is a Java Swing component that allows displaying the (X)HTML documents including the CSS support. It is designed as a JEditorPane replacement with considerably better rendering results. SwingBox is pure Java and it is using the CSSBox rendering engine for rendering the documents.</description>
 	<url>http://cssbox.sourceforge.net/swingbox</url>
@@ -60,18 +60,6 @@
 		<developerConnection>scm:git:git@github.com:radkovo/SwingBox.git</developerConnection>
 	  <tag>HEAD</tag>
   </scm>
-	<distributionManagement>
-        <repository>
-                <id>bds-artifactory</id>
-                <name>integration-releases</name>
-                <url>http://artifactory.blackducksoftware.com:8081/artifactory/integration</url>
-        </repository>
-        <snapshotRepository>
-                <id>artifactory.blackducksoftware.com</id>
-                <name>integration-snapshots</name>
-                <url>http://artifactory.blackducksoftware.com:8081/artifactory/integration-snapshot</url>
-        </snapshotRepository>
-	</distributionManagement>
 	
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>net.sf.cssbox</groupId>
 	<artifactId>swingbox</artifactId>
-	<version>1.1.1</version>
+	<version>1.2-SNAPSHOT</version>
 	<name>SwingBox</name>
 	<description>SwingBox is a Java Swing component that allows displaying the (X)HTML documents including the CSS support. It is designed as a JEditorPane replacement with considerably better rendering results. SwingBox is pure Java and it is using the CSSBox rendering engine for rendering the documents.</description>
 	<url>http://cssbox.sourceforge.net/swingbox</url>

--- a/src/main/java/org/fit/cssbox/swingbox/util/CSSBoxAnalyzer.java
+++ b/src/main/java/org/fit/cssbox/swingbox/util/CSSBoxAnalyzer.java
@@ -38,7 +38,7 @@ public interface CSSBoxAnalyzer
      * Analyzes content from InputSource and constructs a tree of Boxes, which
      * is further processed.
      * 
-     * @param is
+     * @param docSource
      *            the document source implementation.
      * @param dim
      *            the dimension of rendering area.
@@ -52,8 +52,6 @@ public interface CSSBoxAnalyzer
      * Updates the layout according to the new dimmension (the tree structure of
      * view objects has to be modified).
      * 
-     * @param root
-     *            the root box at which to perform update.
      * @param dim
      *            the new dimension of rendering area.
      * @return the box
@@ -64,19 +62,19 @@ public interface CSSBoxAnalyzer
 
     /**
      * Gets parsed W3C document. After calling
-     * {@link CSSBoxAnalyzer#analyze(InputSource, URL, Dimension, Charset)
+     * {@link CSSBoxAnalyzer#analyze(DocumentSource, Dimension)
      * analyze} there should exist such representation.
      * 
      * @return parsed W3C document.
      * @see org.w3c.dom.Document
-     * @see CSSBoxAnalyzer#analyze(InputSource, URL, Dimension, Charset)
+     * @see CSSBoxAnalyzer#analyze(DocumentSource, Dimension)
      */
     public org.w3c.dom.Document getDocument();
     
     /**
      * Obtains the title from the DOM tree of the current document.
-     * The {@link CSSBoxAnalyzer#analyze(InputSource, URL, Dimension, Charset)} method must be called before calling this.
-     * @return The document title or <code>null</code> if there is not title defined.
+     * The {@link CSSBoxAnalyzer#analyze(DocumentSource, Dimension)} method must be called before calling this.
+     * @return The document title or <code>null</code> if there is no title defined.
      */
     public String getDocumentTitle();
     

--- a/src/main/java/org/fit/cssbox/swingbox/util/ContentReader.java
+++ b/src/main/java/org/fit/cssbox/swingbox/util/ContentReader.java
@@ -75,12 +75,12 @@ public class ContentReader implements org.fit.cssbox.render.BoxRenderer
     /**
      * Reads input data and converts them to "elements"
      * 
-     * @param is
-     *            the input source
-     * @param url
-     *            the source of data
+     * @param docSource
+     *            the document source
      * @param cba
      *            the instance of {@link CSSBoxAnalyzer}
+     * @param dim
+     *            the dimension
      * @return the list of elements. Note that, this method returns instance of
      *         LinkedList.
      * @throws IOException

--- a/src/main/java/org/fit/cssbox/swingbox/view/ElementBoxView.java
+++ b/src/main/java/org/fit/cssbox/swingbox/view/ElementBoxView.java
@@ -454,18 +454,18 @@ public class ElementBoxView extends CompositeView implements CSSBoxView
         }
     }
 
-    /**
-     * renders given child, possible to override and customize.
-     * 
-     * @param g
-     *            graphics context
-     * @param v
-     *            the View
-     * @param rect
-     *            an allocation
-     * @param index
-     *            the index of view
-     */
+//    /**
+//     * renders given child, possible to override and customize.
+//     * 
+//     * @param g
+//     *            graphics context
+//     * @param v
+//     *            the View
+//     * @param rect
+//     *            an allocation
+//     * @param index
+//     *            the index of view
+//     */
     /*protected void paintChild(Graphics g, View v, Shape rect, int index)
     {
         // System.err.println("Painting " + v);


### PR DESCRIPTION
First, thanks for coding this great component.

I did make some changes to the pom file to set the xml-apis and Xerces dependencies as provided, because those are by default shipped with the JRE (1.6 or younger) and in environments with "parent-last" classloaders, i.e. IDE plugins, that produces LinkErrors, etc. I also made the same pull request to CSSBox - https://github.com/radkovo/CSSBox/pull/10, which this now depends on.

I also did some small fixes to the javadocs.
