### PR TITLE
Minor code cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /bin
 /target
+.idea
+*.iml

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ Version 1.1 - Sep 1, 2014
 - Improved scrollToReference API
 - Content clipping fixes according to the current CSSBox API
 - URL protocol registration fixes
-- Thread parametres fixed in demos 
+- Thread parameters fixed in demos
 
 Version 1.0 - Feb 10, 2014
 - Drawing order completely rewritten using the new CSSBox API

--- a/src/main/java/org/fit/cssbox/swingbox/BrowserPane.java
+++ b/src/main/java/org/fit/cssbox/swingbox/BrowserPane.java
@@ -189,7 +189,7 @@ public class BrowserPane extends JEditorPane
     }
 
     /**
-     * Gets registred general event listeners.
+     * Gets registered general event listeners.
      * 
      * @return the array of general event listeners
      */
@@ -200,7 +200,7 @@ public class BrowserPane extends JEditorPane
     }
 
     /**
-     * Fires general event. All registred listeners will be notified.
+     * Fires general event. All registered listeners will be notified.
      * 
      * @param e
      *            the event
@@ -258,7 +258,7 @@ public class BrowserPane extends JEditorPane
     /**
      * Renders current content to given graphic context, which is updated and
      * returned. Context must have set the clip, otherwise NullPointerException
-     * is throwen.
+     * is thrown.
      * 
      * @param g
      *            the context to be rendered to.
@@ -301,7 +301,7 @@ public class BrowserPane extends JEditorPane
      * Sets the css box analyzer.
      * 
      * @param cba
-     *            the analyzzer to be set
+     *            the analyzer to be set
      * @return true, if successful
      */
     public boolean setCSSBoxAnalyzer(CSSBoxAnalyzer cba)
@@ -377,7 +377,7 @@ public class BrowserPane extends JEditorPane
         }
         
         int n = root.getElementCount();
-        Element child = null;
+        Element child;
         for (int i = 0; i < n; i++)
         {
             if ((child = findElementToScroll(ref, root.getElement(i))) != null)
@@ -615,7 +615,7 @@ public class BrowserPane extends JEditorPane
     private Document createDocument(EditorKit kit, URL page)
     {
         // we have pageProperties, because we can be in situation that
-        // old page is beeing removed & new page is not yet created...
+        // old page is being removed & new page is not yet created...
         // we need somewhere store important data.
         Document doc = kit.createDefaultDocument();
         if (pageProperties != null)

--- a/src/main/java/org/fit/cssbox/swingbox/SwingBoxDocument.java
+++ b/src/main/java/org/fit/cssbox/swingbox/SwingBoxDocument.java
@@ -41,7 +41,7 @@ public class SwingBoxDocument extends DefaultStyledDocument
     public SwingBoxDocument()
     {
         super();
-        // we do not suuport any inserting, removing or replacing of string & no
+        // we do not support any inserting, removing or replacing of string & no
         // filters
         setDocumentFilter(null);
     }
@@ -128,11 +128,11 @@ public class SwingBoxDocument extends DefaultStyledDocument
             {
                 javax.swing.text.Element data = elems[0];
 
-                for (int i = 0; i < elems.length; i++)
+                for (Element elem : elems)
                 {
-                    if (delegateName.equals(elems[i].getName()))
+                    if (delegateName.equals(elem.getName()))
                     {
-                        data = elems[i];
+                        data = elem;
                         break;
                     }
                 }

--- a/src/main/java/org/fit/cssbox/swingbox/SwingBoxEditorKit.java
+++ b/src/main/java/org/fit/cssbox/swingbox/SwingBoxEditorKit.java
@@ -80,7 +80,7 @@ public class SwingBoxEditorKit extends StyledEditorKit
         String tmp;
         tmp = System.getProperty(Constants.DEFAULT_ANALYZER_PROPERTY,
                 Constants.PROPERTY_NOT_SET);
-        if (tmp == Constants.PROPERTY_NOT_SET)
+        if (tmp.equals(Constants.PROPERTY_NOT_SET))
         {
             // sets property for default analyzer, the fully qualified classname
             // which is used to instantiate this class by reflection
@@ -91,7 +91,7 @@ public class SwingBoxEditorKit extends StyledEditorKit
         tmp = System.getProperty(
                 Constants.DOCUMENT_ASYNCHRONOUS_LOAD_PRIORITY_PROPERTY,
                 Constants.PROPERTY_NOT_SET);
-        if (tmp == Constants.PROPERTY_NOT_SET)
+        if (tmp.equals(Constants.PROPERTY_NOT_SET))
         {
             // property not set, load synchronously !
             System.setProperty(
@@ -146,7 +146,7 @@ public class SwingBoxEditorKit extends StyledEditorKit
         String tmp = System.getProperty(
                 Constants.DOCUMENT_ASYNCHRONOUS_LOAD_PRIORITY_PROPERTY,
                 Constants.PROPERTY_NOT_SET);
-        if (tmp != Constants.PROPERTY_NOT_SET)
+        if (!tmp.equals(Constants.PROPERTY_NOT_SET))
         {
             try
             {
@@ -311,7 +311,7 @@ public class SwingBoxEditorKit extends StyledEditorKit
         String cname = System.getProperty(Constants.DEFAULT_ANALYZER_PROPERTY,
                 Constants.PROPERTY_NOT_SET);
 
-        if (Constants.PROPERTY_NOT_SET == cname)
+        if (Constants.PROPERTY_NOT_SET.equals(cname))
         {
             cba = null;
         }

--- a/src/main/java/org/fit/cssbox/swingbox/demo/BrowserComparison.java
+++ b/src/main/java/org/fit/cssbox/swingbox/demo/BrowserComparison.java
@@ -28,9 +28,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
-import java.net.URLConnection;
 
 import javax.swing.JButton;
 import javax.swing.JEditorPane;
@@ -61,7 +59,7 @@ import org.fit.cssbox.swingbox.util.GeneralEventListener;
 import org.w3c.dom.Document;
 
 /**
- * This demo provides 3 result of same location by 3 renderrers. You will see CSSBox, SwingBox and JEditorPane + HTMLEditorKit.
+ * This demo provides 3 result of same location by 3 renderers. You will see CSSBox, SwingBox and JEditorPane + HTMLEditorKit.
  * Use the "GO!" button to start action.
  * 
  * @author Peter Bielik
@@ -220,8 +218,6 @@ public class BrowserComparison extends JFrame
 
     private void loadPage_cssbox(String urlstring)
     {
-        InputStream is = null;
-
         try
         {
             DocumentSource docSource = new DefaultDocumentSource(urlstring);
@@ -261,19 +257,8 @@ public class BrowserComparison extends JFrame
             });            
             contentScroll.setViewportView(cssbox);
             
-        } catch (Exception e)        {
+        } catch (Exception e) {
             e.printStackTrace();
-        } finally {
-            if (is != null)
-            {
-                try
-                {
-                    is.close();
-                } catch (IOException e)
-                {
-                    e.printStackTrace();
-                }
-            }
         }
     }
 

--- a/src/main/java/org/fit/cssbox/swingbox/demo/SwingBrowser.java
+++ b/src/main/java/org/fit/cssbox/swingbox/demo/SwingBrowser.java
@@ -32,14 +32,10 @@ import org.fit.net.DataURLHandler;
 
 import java.awt.GridBagConstraints;
 
-import javax.swing.JButton;
-import javax.swing.JPanel;
 import javax.swing.text.Document;
 
 import java.awt.Rectangle;
 import java.awt.GridBagLayout;
-
-import javax.swing.JTabbedPane;
 
 import java.awt.Insets;
 import java.awt.event.ActionListener;

--- a/src/main/java/org/fit/cssbox/swingbox/util/CSSBoxAnalyzer.java
+++ b/src/main/java/org/fit/cssbox/swingbox/util/CSSBoxAnalyzer.java
@@ -20,12 +20,9 @@
 package org.fit.cssbox.swingbox.util;
 
 import java.awt.Dimension;
-import java.net.URL;
-import java.nio.charset.Charset;
 
 import org.fit.cssbox.io.DocumentSource;
 import org.fit.cssbox.layout.Viewport;
-import org.xml.sax.InputSource;
 
 /**
  * @author Peter Bielik
@@ -44,21 +41,21 @@ public interface CSSBoxAnalyzer
      *            the dimension of rendering area.
      * @return the tree of boxes.
      * @throws Exception
-     *             some exception may be throwen during processing.
+     *             some exception may be thrown during processing.
      */
-    public Viewport analyze(DocumentSource docSource, Dimension dim) throws Exception;
+    Viewport analyze(DocumentSource docSource, Dimension dim) throws Exception;
 
     /**
-     * Updates the layout according to the new dimmension (the tree structure of
+     * Updates the layout according to the new dimension (the tree structure of
      * view objects has to be modified).
      * 
      * @param dim
      *            the new dimension of rendering area.
      * @return the box
      * @throws Exception
-     *             some exception may be throwen during processing.
+     *             some exception may be thrown during processing.
      */
-    public Viewport update(Dimension dim) throws Exception;
+    Viewport update(Dimension dim) throws Exception;
 
     /**
      * Gets parsed W3C document. After calling
@@ -69,13 +66,13 @@ public interface CSSBoxAnalyzer
      * @see org.w3c.dom.Document
      * @see CSSBoxAnalyzer#analyze(DocumentSource, Dimension)
      */
-    public org.w3c.dom.Document getDocument();
+    org.w3c.dom.Document getDocument();
     
     /**
      * Obtains the title from the DOM tree of the current document.
      * The {@link CSSBoxAnalyzer#analyze(DocumentSource, Dimension)} method must be called before calling this.
      * @return The document title or <code>null</code> if there is no title defined.
      */
-    public String getDocumentTitle();
+    String getDocumentTitle();
     
 }

--- a/src/main/java/org/fit/cssbox/swingbox/util/Constants.java
+++ b/src/main/java/org/fit/cssbox/swingbox/util/Constants.java
@@ -37,7 +37,7 @@ public final class Constants
     public static final String DEFAULT_ANALYZER_PROPERTY = "swingbox.default.analyzer";
     public static final String PROPERTY_NOT_SET = "property_not_set";
 
-    // Attrinutes used by AttributeSet in elements and later in views
+    // Attributes used by AttributeSet in elements and later in views
     public static final String ATTRIBUTE_BOX_REFERENCE = "attribute_box_reference";
     public static final String ATTRIBUTE_ANCHOR_REFERENCE = "attribute_anchor_reference";
     public static final String ATTRIBUTE_ELEMENT_ID = "element_id";

--- a/src/main/java/org/fit/cssbox/swingbox/util/ContentReader.java
+++ b/src/main/java/org/fit/cssbox/swingbox/util/ContentReader.java
@@ -385,7 +385,7 @@ public class ContentReader implements org.fit.cssbox.render.BoxRenderer
     public void renderReplacedContent(ReplacedBox box)
     {
         org.w3c.dom.Element elem = ((ElementBox) box).getElement();
-        String text = "";
+        String text;
         // add some textual info, if picture
         if ("img".equalsIgnoreCase(elem.getTagName()))
         {

--- a/src/main/java/org/fit/cssbox/swingbox/util/DefaultHyperlinkHandler.java
+++ b/src/main/java/org/fit/cssbox/swingbox/util/DefaultHyperlinkHandler.java
@@ -78,7 +78,7 @@ public class DefaultHyperlinkHandler implements HyperlinkListener
     }
 
     /**
-     * Region entered. Called when mouse poionter is over some link
+     * Region entered. Called when mouse pointer is over some link
      * 
      * @param pane
      *            the pane

--- a/src/main/java/org/fit/cssbox/swingbox/util/GeneralEventListener.java
+++ b/src/main/java/org/fit/cssbox/swingbox/util/GeneralEventListener.java
@@ -23,7 +23,7 @@ import java.util.EventListener;
 
 /**
  * This is the "general listener" interface, used for gaining various
- * interesting (but not vital (?)) informations.
+ * interesting (but not vital (?)) information.
  * 
  * @author Peter Bielik
  * @version 1.0
@@ -33,9 +33,9 @@ public interface GeneralEventListener extends EventListener
 {
 
     /**
-     * General event update. Occures, when somthing "interesting" happens.
+     * General event update. Occurs, when something "interesting" happens.
      * 
      * @param e the instance of event with data
      */
-    public void generalEventUpdate(GeneralEvent e);
+    void generalEventUpdate(GeneralEvent e);
 }

--- a/src/main/java/org/fit/cssbox/swingbox/util/MouseController.java
+++ b/src/main/java/org/fit/cssbox/swingbox/util/MouseController.java
@@ -161,8 +161,8 @@ public class MouseController extends MouseAdapter
     private void createHyperLinkEvent(JEditorPane editor, Element elem, Anchor anchor, EventType type)
     {
         HyperlinkEvent linkEvent;
-        String href = (String) anchor.getProperties().get(Constants.ELEMENT_A_ATTRIBUTE_HREF);
-        String target = (String) anchor.getProperties().get(Constants.ELEMENT_A_ATTRIBUTE_TARGET);
+        String href = anchor.getProperties().get(Constants.ELEMENT_A_ATTRIBUTE_HREF);
+        String target = anchor.getProperties().get(Constants.ELEMENT_A_ATTRIBUTE_TARGET);
         URL url;
         URL base = (URL) editor.getDocument().getProperty(DefaultStyledDocument.StreamDescriptionProperty);
         try {

--- a/src/main/java/org/fit/cssbox/swingbox/view/BackgroundView.java
+++ b/src/main/java/org/fit/cssbox/swingbox/view/BackgroundView.java
@@ -116,7 +116,7 @@ public class BackgroundView extends View implements CSSBoxView
         if (graphics instanceof Graphics2D)
             g = (Graphics2D) graphics;
         else
-            throw new RuntimeException("Unknown graphics enviroment, java.awt.Graphics2D required !");
+            throw new RuntimeException("Unknown graphics environment, java.awt.Graphics2D required !");
         
         box.getVisualContext().updateGraphics(g);
         box.drawBackground(g);

--- a/src/main/java/org/fit/cssbox/swingbox/view/BlockReplacedBoxView.java
+++ b/src/main/java/org/fit/cssbox/swingbox/view/BlockReplacedBoxView.java
@@ -127,7 +127,7 @@ public class BlockReplacedBoxView extends BlockBoxView
                         g.setColor(Color.BLACK);
                         //tmpRect = box.getAbsoluteContentBounds();
                         // alternative picture representation (screen readers)
-                        // TODO hint : java accessability !!!
+                        // TODO hint : java accessibility !!!
                         /*g.drawString(alt, tmpRect.x + 2, tmpRect.y
                                 + (int) (tmpRect.height * 0.7));*/
                     }

--- a/src/main/java/org/fit/cssbox/swingbox/view/CSSBoxView.java
+++ b/src/main/java/org/fit/cssbox/swingbox/view/CSSBoxView.java
@@ -44,11 +44,11 @@ public interface CSSBoxView
      * 
      * @return the attributes
      */
-    public AttributeSet getAttributes();
+    AttributeSet getAttributes();
     
     /**
      * Obtains the drawing order of this view
      */
-    public int getDrawingOrder();
+    int getDrawingOrder();
     
 }

--- a/src/main/java/org/fit/cssbox/swingbox/view/DelegateView.java
+++ b/src/main/java/org/fit/cssbox/swingbox/view/DelegateView.java
@@ -111,8 +111,8 @@ public class DelegateView extends CompositeView
         if (offset < offset + length && views.length > 0)
         {
             /*
-             * Actually, we remove old view only, if we have some view to add.We
-             * can not stay empty (no child, no LeafElement-View), otherwiserun
+             * Actually, we remove old view only, if we have some view to add. We
+             * can not stay empty (no child, no LeafElement-View), otherwise run
              * into troubles...
              */
             if (view != null)
@@ -141,7 +141,7 @@ public class DelegateView extends CompositeView
 
             view = tmp;
             /*
-             * setParent is guaranteed to be first method calledafter new
+             * setParent is guaranteed to be first method called after new
              * instance is created.
              */
             view.setParent(this);

--- a/src/main/java/org/fit/cssbox/swingbox/view/ElementBoxView.java
+++ b/src/main/java/org/fit/cssbox/swingbox/view/ElementBoxView.java
@@ -436,7 +436,7 @@ public class ElementBoxView extends CompositeView implements CSSBoxView
         if (graphics instanceof Graphics2D)
             g = (Graphics2D) graphics;
         else
-            throw new RuntimeException("Unknown graphics enviroment, java.awt.Graphics2D required !");
+            throw new RuntimeException("Unknown graphics environment, java.awt.Graphics2D required !");
 
         Rectangle clip = toRect(g.getClip());
         
@@ -743,7 +743,7 @@ public class ElementBoxView extends CompositeView implements CSSBoxView
 
         /*
          * in current implementation we do not support propagation do childs,
-         * beacuse, if there is a change, world is rebuilt..
+         * because, if there is a change, world is rebuilt..
          */
     }
 

--- a/src/main/java/org/fit/cssbox/swingbox/view/InlineReplacedBoxView.java
+++ b/src/main/java/org/fit/cssbox/swingbox/view/InlineReplacedBoxView.java
@@ -113,7 +113,7 @@ public class InlineReplacedBoxView extends InlineBoxView
                         g.setColor(Color.BLACK);
                         //tmpRect = box.getAbsoluteContentBounds();
                         // alternative picture representation (screen readers)
-                        // TODO hint : java accessability !!!
+                        // TODO hint : java accessibility !!!
                         //g.drawString(alt, tmpRect.x + 2, tmpRect.y
                         //        + (int) (tmpRect.height * 0.7));
                     }

--- a/src/main/java/org/fit/cssbox/swingbox/view/TextBoxView.java
+++ b/src/main/java/org/fit/cssbox/swingbox/view/TextBoxView.java
@@ -172,7 +172,7 @@ public class TextBoxView extends View implements CSSBoxView
                 Anchor parentAnchor = ((ElementBoxView) parent).getAnchor();
                 if (parentAnchor.isActive())
                 {
-                    // share elemntAttributes
+                    // share elementAttributes
                     anchor.setActive(true);
                     anchor.getProperties().putAll(parentAnchor.getProperties());
                 }
@@ -478,7 +478,7 @@ public class TextBoxView extends View implements CSSBoxView
             }
             if (strike)
             {
-                int yy = y + (int) (absoluteContentBounds.height / 2);
+                int yy = y + absoluteContentBounds.height / 2;
                 g.drawLine(absoluteContentBounds.x, yy, xx, yy);
             }
             
@@ -686,9 +686,9 @@ public class TextBoxView extends View implements CSSBoxView
         {
             FontVariant val[] = FontVariant.values();
 
-            for (int i = 0; i < val.length; i++)
+            for (FontVariant aVal : val)
             {
-                if (val[i].toString().equals(newFontVariant))
+                if (aVal.toString().equals(newFontVariant))
                 {
                     fontVariant = newFontVariant;
                     invalidateCache();
@@ -722,19 +722,17 @@ public class TextBoxView extends View implements CSSBoxView
         strike = false;
         overline = false;
 
-        TextDecoration val;
-        for (int i = 0; i < decor.size(); i++)
+        for (TextDecoration aDecor : decor)
         {
-            val = decor.get(i);
-            if (TextDecoration.UNDERLINE == val)
+            if (TextDecoration.UNDERLINE == aDecor)
             {
                 underline = true;
             }
-            else if (TextDecoration.LINE_THROUGH == val)
+            else if (TextDecoration.LINE_THROUGH == aDecor)
             {
                 strike = true;
             }
-            else if (TextDecoration.OVERLINE == val)
+            else if (TextDecoration.OVERLINE == aDecor)
             {
                 overline = true;
             }


### PR DESCRIPTION
Minor code cleanups:
(1) spelling
(2) use foreach
(3) remove redundant casts
(4) remove redundant initializations
(5) use equals() on string types
(6) remove unused imports
(7) remove redundant public modifiers on interfaces
(8) remove unused input stream variable and associated unused finally block